### PR TITLE
Placeholder on string fields

### DIFF
--- a/src/javascript/dom/builder/fragment/string.js
+++ b/src/javascript/dom/builder/fragment/string.js
@@ -35,7 +35,7 @@ class String extends Base {
       {
         selector: '.dynamic_form_input',
         attributes: {
-          placeholder: options.data.title,
+          placeholder: options.data.placeholder,
           name: options.data.key,
           value: options.data.value
         }

--- a/src/javascript/dom/builder/fragment/string.js
+++ b/src/javascript/dom/builder/fragment/string.js
@@ -35,7 +35,7 @@ class String extends Base {
       {
         selector: '.dynamic_form_input',
         attributes: {
-          placeholder: typeof options.data.placeholder !== 'undefined' ? options.data.placeholder : options.data.title
+          placeholder: typeof options.data.placeholder !== 'undefined' ? options.data.placeholder : options.data.title,
           name: options.data.key,
           value: options.data.value
         }

--- a/src/javascript/dom/builder/fragment/string.js
+++ b/src/javascript/dom/builder/fragment/string.js
@@ -35,7 +35,7 @@ class String extends Base {
       {
         selector: '.dynamic_form_input',
         attributes: {
-          placeholder: options.data.placeholder,
+          placeholder: typeof options.data.placeholder !== 'undefined' ? options.data.placeholder : options.data.title
           name: options.data.key,
           value: options.data.value
         }


### PR DESCRIPTION
### What is the goal?

Show correct placeholder on string fields

- [ ] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [ ] The `README.md` has been updated accordingly
- [ ] **Issue:** (small PR's don't need it)

### How is being implemented?

Just modify the data key to get the correct placeholder

### Reviewers

@jobandtalent/frontend 

