### PR TITLE
Tooltip component

### DIFF
--- a/src/component/tooltip/main.less
+++ b/src/component/tooltip/main.less
@@ -1,0 +1,84 @@
+@import '../../stylesheets/colors.less';
+@import '../../stylesheets/typography.less';
+@import '../../stylesheets/mixins.less';
+
+@tooltipBg: rgb(47, 50, 58);
+@tooltipTitleColor: rgb(135, 192, 81);
+
+.tooltip_box {
+  position: absolute;
+  top: -9999px;
+  left: -9999px;
+  transition: none !important;
+  opacity: 0;
+  z-index: 3;
+  font-size: 14px;
+
+  .tooltip_wrapper {
+    position: relative;
+  }
+
+  .tooltip_header {
+    padding-right: 25px;
+  }
+
+  .tooltip_close {
+    position: absolute;
+    right: 11px;
+    top: 8px;
+    outline: 0;
+  }
+
+  .tooltip_title {
+    color: @tooltipTitleColor;
+    margin-bottom: 8px;
+    .semi_bold;
+  }
+
+  .tooltip_close_text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip:rect(0,0,0,0);
+    border: 0;
+  }
+
+  .tooltip_content {
+    color: @high-light-text;
+    line-height: 1.5;
+  }
+
+  .tooltip_content_wrapper {
+    position: relative;
+    max-width: 288px;
+    padding: 16px;
+    box-sizing: border-box;
+    background-color: @tooltipBg;
+    .border-radius(5px);
+    .box-shadow(0px 0px 5px 0px rgba(0,0,0,0.2));
+  }
+
+  &.arrow_top {
+    padding-top: 8px;
+  }
+
+  &.arrow_bottom {
+    padding-bottom: 8px;
+  }
+
+  &.arrow_left {
+    padding-left: 8px;
+  }
+
+  &.arrow_right {
+    padding-right: 8px;
+  }
+
+  .tooltip_arrow {
+    position: absolute;
+    z-index: 1;
+  }
+}

--- a/src/component/tooltip/template.html
+++ b/src/component/tooltip/template.html
@@ -1,0 +1,17 @@
+<aside class="tooltip_box" rel="<%= rel -%>">
+  <div class="tooltip_wrapper">
+    <i class="js_tooltip_arrow tooltip_arrow sprite"></i>
+    <div class="tooltip_content_wrapper">
+      <header class="tooltip_header">
+        <h1 class="tooltip_title"><%= name -%></h1>
+        <%= link_to "#", class: "tooltip_close js_tooltip_close" do %>
+          <span class="tooltip_close_text"><%= t("words.close") %></span>
+          <i class="sprite sprite_tooltip_close"></i>
+        <% end %>
+      </header>
+      <div class="tooltip_content">
+        <%= capture(&block) %>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -5,6 +5,8 @@ import BaseController from '../../javascript/component/base/base-controller';
 import CookieStorage from '../../javascript/cookie-storage';
 
 class TooltipController extends BaseController {
+  _cookieId: string;
+  _showOnce: boolean;
 
   /**
    * @param {Object} options

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -1,0 +1,34 @@
+/* @flow */
+'use strict';
+
+import BaseController from '../../javascript/component/base/base-controller';
+import CookieStorage from '../../javascript/cookie-storage';
+
+class TooltipController extends BaseController {
+  constructor(options: Object = {}) {
+    options.id = 'Tooltip'; // eslint-disable-line no-param-reassign
+    super(options);
+    this._once = this._options.once || false;
+    this._cookieId = this._options.locator;
+  }
+
+  show(): void {
+    if (this._once) {
+      if (CookieStorage.get(this._cookieId) !== 'yes') {
+        CookieStorage.set(this._cookieId, 'yes', { expires: 9999 });
+        this._store.dispatch({ type: 'show' });
+        this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
+      }
+    } else {
+      this._store.dispatch({ type: 'show' });
+      this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
+    }
+  }
+
+  close(): void {
+    this._store.dispatch({ type: 'close' });
+    this._eventBus.publish(`close${this._id}`, { locator: this._options.locator });
+  }
+}
+
+export default TooltipController;

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -5,6 +5,12 @@ import BaseController from '../../javascript/component/base/base-controller';
 import CookieStorage from '../../javascript/cookie-storage';
 
 class TooltipController extends BaseController {
+
+  /**
+   * @param {Object} options
+   * @constructor
+   */
+
   constructor(options: Object = {}) {
     options.id = 'Tooltip'; // eslint-disable-line no-param-reassign
     super(options);
@@ -12,6 +18,9 @@ class TooltipController extends BaseController {
     this._cookieId = this._options.locator;
   }
 
+  /**
+   * @method show
+   */
   show(): void {
     if (this._once) {
       if (CookieStorage.get(this._cookieId) !== 'yes') {
@@ -25,6 +34,9 @@ class TooltipController extends BaseController {
     }
   }
 
+  /**
+   * @method close
+   */
   close(): void {
     this._store.dispatch({ type: 'close' });
     this._eventBus.publish(`close${this._id}`, { locator: this._options.locator });

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -10,7 +10,6 @@ class TooltipController extends BaseController {
    * @param {Object} options
    * @constructor
    */
-
   constructor(options: Object = {}) {
     options.id = 'Tooltip'; // eslint-disable-line no-param-reassign
     super(options);

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -20,6 +20,7 @@ class TooltipController extends BaseController {
 
   /**
    * @method show
+   * @public
    */
   show(): void {
     if (this._once) {
@@ -36,6 +37,7 @@ class TooltipController extends BaseController {
 
   /**
    * @method close
+   * @public
    */
   close(): void {
     this._store.dispatch({ type: 'close' });

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -14,7 +14,7 @@ class TooltipController extends BaseController {
   constructor(options: Object = {}) {
     options.id = 'Tooltip'; // eslint-disable-line no-param-reassign
     super(options);
-    this._once = this._options.once || false;
+    this._showOnce = this._options.showOnce || false;
     this._cookieId = this._options.locator;
   }
 
@@ -23,7 +23,7 @@ class TooltipController extends BaseController {
    * @public
    */
   show(): void {
-    if (this._once) {
+    if (this._showOnce) {
       if (CookieStorage.get(this._cookieId) !== 'yes') {
         CookieStorage.set(this._cookieId, 'yes', { expires: 9999 });
         this._store.dispatch({ type: 'show' });

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -7,6 +7,14 @@ import BaseView from '../../javascript/component/base/base-view';
 import '!style!css!less!./main.less';
 
 class TooltipView extends BaseView {
+  _tooltip: Element;
+  _target: Element;
+  _pointedSide: string;
+  _alignment: string;
+  _direction: string;
+  _gap: number;
+  _position: string;
+  _showClose: boolean;
 
   /**
    * @param {Object} options
@@ -36,16 +44,11 @@ class TooltipView extends BaseView {
     this._alignment = this._getAlignment(this._controller._options.at);
     this._direction = this._getDirection();
     this._gap = this._controller._options.gap || 12;
-    this._defaultPosition = 'absolute';
-    this._position = this._controller._options.position || this._defaultPosition;
+    this._position = this._getCSSPosition(this._controller._options.position);
     this._showClose = this._controller._options.showClose || false;
 
     if (!this._showClose) {
       this._tooltip.querySelector(this.locators.closeElement).remove();
-    }
-
-    if (this._position !== this._defaultPosition && this._position !== 'fixed') {
-      throw new Error("position value has to be absolute or fixed");
     }
 
     this._positionate();
@@ -391,6 +394,22 @@ class TooltipView extends BaseView {
     } else {
       return 'horizontal';
     }
+  }
+
+  /**
+   * @method _getCSSPosition
+   * @returns {string}
+   * @private
+   */
+  _getCSSPosition(position: string): string {
+    const defaultCSSPosition = 'absolute';
+    const positionCSSValue = position || defaultCSSPosition;
+
+    if (position !== defaultCSSPosition && position !== 'fixed') {
+      throw new Error("position value has to be absolute or fixed");
+    }
+
+    return positionCSSValue;
   }
 }
 

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -38,9 +38,9 @@ class TooltipView extends BaseView {
     this._gap = this._controller._options.gap || 12;
     this._defaultPosition = 'absolute';
     this._position = this._controller._options.position || this._defaultPosition;
-    this._closeElement = this._controller._options.closeElement || false;
+    this._showClose = this._controller._options.showClose || false;
 
-    if (!this._closeElement) {
+    if (!this._showClose) {
       this._tooltip.querySelector(this.locators.closeElement).remove();
     }
 
@@ -191,10 +191,10 @@ class TooltipView extends BaseView {
   }
 
   /**
-   * @method _setVerticalAndHorizontalAtPositions
+   * @method _positionateOverTarget
    * @private
    */
-  _setVerticalAndHorizontalAtPositions(): void {
+  _positioningRelationToTarget(): void {
     const triggerPosition = this._targetPosition();
     let verticalPosition = null;
     let horizontalPosition = null;
@@ -304,7 +304,7 @@ class TooltipView extends BaseView {
    * @private
    */
   _toPixels(pixels: number): string {
-    return pixels + "px";
+    return `${pixels}px`;
   }
 
   /**

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -1,0 +1,288 @@
+/* @flow */
+'use strict';
+
+import BaseView from '../../javascript/component/base/base-view';
+
+// $FlowFixMe
+import '!style!css!less!./main.less';
+
+class TooltipView extends BaseView {
+  constructor(options: Object) {
+    options.locators = { // eslint-disable-line no-param-reassign
+      arrow: '.js_tooltip_arrow',
+      closeElement: '.js_tooltip_close',
+      closeTooltip: document
+    };
+    super(options);
+
+    this._defaultAtPosition = "bottom left";
+
+    this._allowedPositions = [
+      "top left",
+      "top center",
+      "top right",
+      "left top",
+      "left center",
+      "left bottom",
+      "right top",
+      "right center",
+      "right bottom",
+      "bottom left",
+      "bottom center",
+      "bottom right"
+    ];
+
+    this._tooltip = document.querySelector(this.locators.main);
+
+    if (this._tooltip === null) {
+      throw new Error("tooltip has not been found");
+    }
+
+    this._trigger = document.querySelector(this._controller._options.trigger);
+
+    if (this._trigger === null) {
+      throw new Error("tooltip trigger has not been found");
+    }
+
+    this._at = this._controller._options.at;
+
+    if (typeof this._at === 'undefined') {
+      this._at = this._defaultAtPosition;
+    } else {
+      if (typeof this._at !== 'string' ||
+          !this._allowedPositions.includes(this._at)) {
+        throw new Error("'at' position is not allowed. Please set one of the following: " +
+          this._allowedPositions.join(", "));
+      }
+    }
+
+    this._at = this._at.split(' ');
+    this._side = this._at[0];
+
+    if (this._side === 'left' || this._side === 'right') {
+      this._direction = 'vertical';
+    } else {
+      this._direction = 'horizontal';
+    }
+
+    this._alignment = this._at[1];
+    this._gap = this._controller._options.gap || 12;
+    this._defaultPosition = 'absolute';
+    this._position = this._controller._options.position || this._defaultPosition;
+    this._closeElement = this._controller._options.closeElement || false;
+
+    if (!this._closeElement) {
+      this._tooltip.querySelector(this.locators.closeElement).remove();
+    }
+
+    if (this._position !== this._defaultPosition && this._position !== 'fixed') {
+      throw new Error("position value has to be absolute or fixed");
+    }
+
+    this._positionate();
+  }
+
+  show(): void {
+    this._tooltip.style.opacity = "1";
+    this._tooltip.style.display = "block";
+  }
+
+  close(): void {
+    this._tooltip.style.display = "none";
+  }
+
+  onClick(event: Object): void {
+    var clickedElement = event.target;
+    const closeElementClass = this.locators.closeElement.substring(1);
+
+    if (this._tooltip.hasChildNodes(clickedElement) &&
+        (clickedElement.className.indexOf(closeElementClass) !== -1 ||
+         clickedElement.parentElement.className.indexOf(closeElementClass) !== -1)) {
+      this.close();
+    }
+  }
+
+  _positionate(): void {
+    this._appendToBody();
+    this._setCSSPosition();
+    this._orientateArrow();
+    this._positionateArrow();
+    this._setVerticalAndHorizontalAtPositions();
+    this._offsettingPosition();
+  }
+
+  _setCSSPosition(): void {
+    if (this._position !== this._defaultPosition) {
+      this._tooltip.style.position = this._position;
+    }
+  }
+
+  _appendToBody(): void {
+    if (this._tooltip.parentNode !== document.body) {
+      const clonedTooltip = this._tooltip.cloneNode(true);
+      this._tooltip.remove();
+      this._tooltip = document.body.appendChild(clonedTooltip);
+    }
+  }
+
+  _orientateArrow(): void {
+    const arrowOrientationMap = {
+      'top': 'bottom',
+      'bottom': 'top',
+      'left': 'right',
+      'right': 'left'
+    }
+    const arrowClassList = ['arrow'];
+
+    arrowClassList.push(arrowOrientationMap[this._side]);
+    arrowClassList.push(this._alignment);
+    const arrowClassName = arrowClassList.join('_');
+
+    if (this._tooltip.className.indexOf(arrowClassName) === -1) {
+      this._tooltip.className += ' ' + arrowClassName;
+    }
+  }
+
+  _positionateArrow(): void {
+    const tooltipPosition = this._tooltipPosition();
+    const triggerPosition = this._triggerPosition();
+    const arrow = document.querySelector('.js_tooltip_arrow');
+    const arrowPosition = arrow.getBoundingClientRect();
+
+    if (this._direction === 'horizontal') {
+      const tooltipWidth = tooltipPosition.width;
+      const triggerWidth = triggerPosition.width;
+
+      if (tooltipWidth >= triggerWidth) {
+        const triggerCenter = triggerPosition.width/2;
+
+        if ((this._alignment === 'left' &&
+            triggerCenter > 3/2 * arrowPosition.width) ||
+            (this._alignment === 'right' &&
+            triggerCenter < tooltipPosition.width - 3/2 * arrowPosition.width)) {
+          arrow.style[this._alignment] = this._toPixels(triggerCenter);
+          arrow.style.marginLeft = this._toPixels(-arrowPosition.width/2);
+        }
+      } else {
+        arrow.style.left = '50%';
+        arrow.style.marginLeft = this._toPixels(-arrowPosition.width/2);
+      }
+    } else {
+      const tooltipHeight = tooltipPosition.height;
+      const triggerHeight = triggerPosition.height;
+
+      if (tooltipHeight >= triggerHeight) {
+        const triggerCenter = triggerPosition.height/2;
+
+        if ((this._alignment === 'top' &&
+            triggerCenter > 3/2 * arrowPosition.height) ||
+            (this._alignment === 'bottom' &&
+            triggerCenter < tooltipPosition.height - 3/2 * arrowPosition.height)) {
+          arrow.style[this._alignment] = this._toPixels(triggerCenter);
+          arrow.style.marginTop = this._toPixels(-arrowPosition.height/2);
+        }
+      } else {
+        arrow.style.top = '50%';
+        arrow.style.marginTop = this._toPixels(-arrowPosition.height/2);
+      }
+    }
+  }
+
+  _setVerticalAndHorizontalAtPositions(): void {
+    const triggerPosition = this._triggerPosition();
+    let verticalPosition = null;
+    let horizontalPosition = null;
+
+    if (this._direction === 'horizontal') {
+      verticalPosition = triggerPosition[this._side];
+
+      if (this._alignment !== 'center') {
+        horizontalPosition = triggerPosition[this._alignment];
+      } else {
+        horizontalPosition = triggerPosition.left + triggerPosition.width/2;
+      }
+    } else {
+      horizontalPosition = triggerPosition[this._side];
+
+      if (this._alignment !== 'center') {
+        verticalPosition = triggerPosition[this._alignment];
+      } else {
+        verticalPosition = triggerPosition.top + triggerPosition.height/2;
+      }
+    }
+
+    this._positionateTop(verticalPosition);
+    this._positionateLeft(horizontalPosition);
+  }
+
+  _offsettingPosition(): void {
+    const tooltipPosition = this._tooltipPosition();
+    let verticalPosition = tooltipPosition.top;
+    let horizontalPosition = tooltipPosition.left;
+
+    if (this._direction === 'horizontal') {
+      verticalPosition += this._calculateGap();
+
+      if (this._alignment === 'center') {
+        horizontalPosition -= tooltipPosition.width/2;
+      }
+
+      if (this._alignment === 'right') {
+        horizontalPosition -= tooltipPosition.width;
+      }
+    } else {
+      horizontalPosition += this._calculateGap();
+
+      if (this._alignment === 'center') {
+        verticalPosition -= tooltipPosition.height/2;
+      }
+
+      if (this._alignment === 'right') {
+        verticalPosition -= tooltipPosition.height;
+      }
+    }
+
+    this._positionateLeft(horizontalPosition);
+    this._positionateTop(verticalPosition);
+  }
+
+  _calculateGap(): number {
+    let gap = this._gap;
+
+    if (this._side === 'top' || this._side === 'left') {
+      gap = -gap;
+    }
+
+    return gap;
+  }
+
+  _positionateTop(top: number): void {
+    if (this._tooltip.style.bottom !== '') {
+      this._tooltip.style.bottom = null;
+    }
+
+    this._tooltip.style.top = this._toPixels(top);
+  }
+
+  _positionateLeft(left: number): void {
+    if (this._tooltip.style.right !== '') {
+      this._tooltip.style.right = null;
+    }
+
+    this._tooltip.style.left = this._toPixels(left);
+  }
+
+  _toPixels(pixels: number): string {
+    return pixels + "px";
+  }
+
+  _tooltipPosition(): Object {
+    return this._tooltip.getBoundingClientRect();
+  }
+
+  _triggerPosition(): Object {
+    return this._trigger.getBoundingClientRect();
+  }
+}
+
+export default TooltipView;

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -43,10 +43,10 @@ class TooltipView extends BaseView {
       throw new Error("tooltip has not been found");
     }
 
-    this._trigger = document.querySelector(this._controller._options.trigger);
+    this._target = document.querySelector(this._controller._options.trigger);
 
-    if (this._trigger === null) {
-      throw new Error("tooltip trigger has not been found");
+    if (this._target === null) {
+      throw new Error("tooltip target has not been found");
     }
 
     this._at = this._controller._options.at;
@@ -180,7 +180,7 @@ class TooltipView extends BaseView {
    */
   _positionateArrow(): void {
     const tooltipPosition = this._tooltipPosition();
-    const triggerPosition = this._triggerPosition();
+    const triggerPosition = this._targetPosition();
     const arrow = document.querySelector('.js_tooltip_arrow');
     const arrowPosition = arrow.getBoundingClientRect();
 
@@ -228,7 +228,7 @@ class TooltipView extends BaseView {
    * @private
    */
   _setVerticalAndHorizontalAtPositions(): void {
-    const triggerPosition = this._triggerPosition();
+    const triggerPosition = this._targetPosition();
     let verticalPosition = null;
     let horizontalPosition = null;
 
@@ -350,12 +350,12 @@ class TooltipView extends BaseView {
   }
 
   /**
-   * @method _triggerPosition
+   * @method _targetPosition
    * @returns {Object}
    * @private
    */
-  _triggerPosition(): Object {
-    return this._trigger.getBoundingClientRect();
+  _targetPosition(): Object {
+    return this._target.getBoundingClientRect();
   }
 }
 

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -7,6 +7,11 @@ import BaseView from '../../javascript/component/base/base-view';
 import '!style!css!less!./main.less';
 
 class TooltipView extends BaseView {
+
+  /**
+   * @param {Object} options
+   * @constructor
+   */
   constructor(options: Object) {
     options.locators = { // eslint-disable-line no-param-reassign
       arrow: '.js_tooltip_arrow',
@@ -82,15 +87,25 @@ class TooltipView extends BaseView {
     this._positionate();
   }
 
+  /**
+   * @method show
+   */
   show(): void {
     this._tooltip.style.opacity = "1";
     this._tooltip.style.display = "block";
   }
 
+  /**
+   * @method close
+   */
   close(): void {
     this._tooltip.style.display = "none";
   }
 
+  /**
+   * @param {Object} event
+   * @method onClick
+   */
   onClick(event: Object): void {
     var clickedElement = event.target;
     const closeElementClass = this.locators.closeElement.substring(1);
@@ -102,6 +117,10 @@ class TooltipView extends BaseView {
     }
   }
 
+  /**
+   * @method _positionate
+   * @private
+   */
   _positionate(): void {
     this._appendToBody();
     this._setCSSPosition();
@@ -111,12 +130,20 @@ class TooltipView extends BaseView {
     this._offsettingPosition();
   }
 
+  /**
+   * @method _setCSSPosition
+   * @private
+   */
   _setCSSPosition(): void {
     if (this._position !== this._defaultPosition) {
       this._tooltip.style.position = this._position;
     }
   }
 
+  /**
+   * @method _appendToBody
+   * @private
+   */
   _appendToBody(): void {
     if (this._tooltip.parentNode !== document.body) {
       const clonedTooltip = this._tooltip.cloneNode(true);
@@ -125,6 +152,10 @@ class TooltipView extends BaseView {
     }
   }
 
+  /**
+   * @method _orientateArrow
+   * @private
+   */
   _orientateArrow(): void {
     const arrowOrientationMap = {
       'top': 'bottom',
@@ -143,6 +174,10 @@ class TooltipView extends BaseView {
     }
   }
 
+  /**
+   * @method _positionateArrow
+   * @private
+   */
   _positionateArrow(): void {
     const tooltipPosition = this._tooltipPosition();
     const triggerPosition = this._triggerPosition();
@@ -188,6 +223,10 @@ class TooltipView extends BaseView {
     }
   }
 
+  /**
+   * @method _setVerticalAndHorizontalAtPositions
+   * @private
+   */
   _setVerticalAndHorizontalAtPositions(): void {
     const triggerPosition = this._triggerPosition();
     let verticalPosition = null;
@@ -215,6 +254,10 @@ class TooltipView extends BaseView {
     this._positionateLeft(horizontalPosition);
   }
 
+  /**
+   * @method _offsettingPosition
+   * @private
+   */
   _offsettingPosition(): void {
     const tooltipPosition = this._tooltipPosition();
     let verticalPosition = tooltipPosition.top;
@@ -246,6 +289,11 @@ class TooltipView extends BaseView {
     this._positionateTop(verticalPosition);
   }
 
+  /**
+   * @method _calculateGap
+   * @returns {number}
+   * @private
+   */
   _calculateGap(): number {
     let gap = this._gap;
 
@@ -256,6 +304,11 @@ class TooltipView extends BaseView {
     return gap;
   }
 
+  /**
+   * @param {number} top
+   * @method _positionateTop
+   * @private
+   */
   _positionateTop(top: number): void {
     if (this._tooltip.style.bottom !== '') {
       this._tooltip.style.bottom = null;
@@ -264,6 +317,11 @@ class TooltipView extends BaseView {
     this._tooltip.style.top = this._toPixels(top);
   }
 
+  /**
+   * @param {number} left
+   * @method _positionateLeft
+   * @private
+   */
   _positionateLeft(left: number): void {
     if (this._tooltip.style.right !== '') {
       this._tooltip.style.right = null;
@@ -272,14 +330,30 @@ class TooltipView extends BaseView {
     this._tooltip.style.left = this._toPixels(left);
   }
 
+  /**
+   * @param {number} pixels
+   * @method _toPixels
+   * @returns {string}
+   * @private
+   */
   _toPixels(pixels: number): string {
     return pixels + "px";
   }
 
+  /**
+   * @method _tooltipPosition
+   * @returns {Object}
+   * @private
+   */
   _tooltipPosition(): Object {
     return this._tooltip.getBoundingClientRect();
   }
 
+  /**
+   * @method _triggerPosition
+   * @returns {Object}
+   * @private
+   */
   _triggerPosition(): Object {
     return this._trigger.getBoundingClientRect();
   }

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -93,8 +93,8 @@ class TooltipView extends BaseView {
     this._setCSSPosition();
     this._orientateArrow();
     this._positionateArrow();
-    this._setVerticalAndHorizontalAtPositions();
-    this._offsettingPosition();
+    this._computePosition();
+    this._addExtraOffset();
   }
 
   /**
@@ -191,10 +191,10 @@ class TooltipView extends BaseView {
   }
 
   /**
-   * @method _positionateOverTarget
+   * @method _computePosition
    * @private
    */
-  _positioningRelationToTarget(): void {
+  _computePosition(): void {
     const triggerPosition = this._targetPosition();
     let verticalPosition = null;
     let horizontalPosition = null;
@@ -222,10 +222,10 @@ class TooltipView extends BaseView {
   }
 
   /**
-   * @method _offsettingPosition
+   * @method _addExtraOffset
    * @private
    */
-  _offsettingPosition(): void {
+  _addExtraOffset(): void {
     const tooltipPosition = this._tooltipPosition();
     let verticalPosition = tooltipPosition.top;
     let horizontalPosition = tooltipPosition.left;

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -89,6 +89,7 @@ class TooltipView extends BaseView {
 
   /**
    * @method show
+   * @public
    */
   show(): void {
     this._tooltip.style.opacity = "1";
@@ -97,6 +98,7 @@ class TooltipView extends BaseView {
 
   /**
    * @method close
+   * @public
    */
   close(): void {
     this._tooltip.style.display = "none";
@@ -105,6 +107,7 @@ class TooltipView extends BaseView {
   /**
    * @param {Object} event
    * @method onClick
+   * @public
    */
   onClick(event: Object): void {
     var clickedElement = event.target;

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -20,57 +20,21 @@ class TooltipView extends BaseView {
     };
     super(options);
 
-    this._defaultAtPosition = "bottom left";
-
-    this._allowedPositions = [
-      "top left",
-      "top center",
-      "top right",
-      "left top",
-      "left center",
-      "left bottom",
-      "right top",
-      "right center",
-      "right bottom",
-      "bottom left",
-      "bottom center",
-      "bottom right"
-    ];
-
     this._tooltip = document.querySelector(this.locators.main);
 
     if (this._tooltip === null) {
       throw new Error("tooltip has not been found");
     }
 
-    this._target = document.querySelector(this._controller._options.trigger);
+    this._target = document.querySelector(this._controller._options.target);
 
     if (this._target === null) {
       throw new Error("tooltip target has not been found");
     }
 
-    this._at = this._controller._options.at;
-
-    if (typeof this._at === 'undefined') {
-      this._at = this._defaultAtPosition;
-    } else {
-      if (typeof this._at !== 'string' ||
-          !this._allowedPositions.includes(this._at)) {
-        throw new Error("'at' position is not allowed. Please set one of the following: " +
-          this._allowedPositions.join(", "));
-      }
-    }
-
-    this._at = this._at.split(' ');
-    this._side = this._at[0];
-
-    if (this._side === 'left' || this._side === 'right') {
-      this._direction = 'vertical';
-    } else {
-      this._direction = 'horizontal';
-    }
-
-    this._alignment = this._at[1];
+    this._pointedSide = this._getPointedSide(this._controller._options.at);
+    this._alignment = this._getAlignment(this._controller._options.at);
+    this._direction = this._getDirection();
     this._gap = this._controller._options.gap || 12;
     this._defaultPosition = 'absolute';
     this._position = this._controller._options.position || this._defaultPosition;
@@ -168,7 +132,7 @@ class TooltipView extends BaseView {
     }
     const arrowClassList = ['arrow'];
 
-    arrowClassList.push(arrowOrientationMap[this._side]);
+    arrowClassList.push(arrowOrientationMap[this._pointedSide]);
     arrowClassList.push(this._alignment);
     const arrowClassName = arrowClassList.join('_');
 
@@ -236,7 +200,7 @@ class TooltipView extends BaseView {
     let horizontalPosition = null;
 
     if (this._direction === 'horizontal') {
-      verticalPosition = triggerPosition[this._side];
+      verticalPosition = triggerPosition[this._pointedSide];
 
       if (this._alignment !== 'center') {
         horizontalPosition = triggerPosition[this._alignment];
@@ -244,7 +208,7 @@ class TooltipView extends BaseView {
         horizontalPosition = triggerPosition.left + triggerPosition.width/2;
       }
     } else {
-      horizontalPosition = triggerPosition[this._side];
+      horizontalPosition = triggerPosition[this._pointedSide];
 
       if (this._alignment !== 'center') {
         verticalPosition = triggerPosition[this._alignment];
@@ -300,7 +264,7 @@ class TooltipView extends BaseView {
   _calculateGap(): number {
     let gap = this._gap;
 
-    if (this._side === 'top' || this._side === 'left') {
+    if (this._poinetdSide === 'top' || this._pointedSide === 'left') {
       gap = -gap;
     }
 
@@ -359,6 +323,74 @@ class TooltipView extends BaseView {
    */
   _targetPosition(): Object {
     return this._target.getBoundingClientRect();
+  }
+
+  /**
+   * @method _convertAtValueToArray
+   * @param {string} at
+   * @returns {Array}
+   * @private
+   */
+  _convertAtValueToArray(at: string): Array<string> {
+    const allowedPositions = [
+      "top left",
+      "top center",
+      "top right",
+      "left top",
+      "left center",
+      "left bottom",
+      "right top",
+      "right center",
+      "right bottom",
+      "bottom left",
+      "bottom center",
+      "bottom right"
+    ];
+
+    if (typeof at === 'undefined') {
+      at = "bottom left";
+    } else {
+      if (typeof at !== 'string' ||
+          !allowedPositions.includes(at)) {
+        throw new Error("'at' position is not allowed. Please set one of the following: " +
+          allowedPositions.join(", "));
+      }
+    }
+
+    return at.split(' ');
+  }
+
+  /**
+   * @method _getPointedSide
+   * @param {string} at
+   * @returns {string}
+   * @private
+   */
+  _getPointedSide(at: string): string {
+    return this._convertAtValueToArray(at)[0];
+  }
+
+  /**
+   * @method _getAlignment
+   * @param {string} at
+   * @returns {string}
+   * @private
+   */
+  _getAlignment(at: string): string {
+    return this._convertAtValueToArray(at)[1];
+  }
+
+  /**
+   * @method _getDirection
+   * @returns {string}
+   * @private
+   */
+  _getDirection(): string {
+    if (this._pointedSide === 'left' || this._pointedSide === 'right') {
+      return 'vertical';
+    } else {
+      return 'horizontal';
+    }
   }
 }
 

--- a/src/javascript/component/base/event.js
+++ b/src/javascript/component/base/event.js
@@ -12,4 +12,4 @@ export const ElementEvents = ['click', 'keypress', 'keyup', 'keydown'];
  * @see https://developer.mozilla.org/en-US/docs/Web/Events
  * @module DocumentEvents
  */
-export const DocumentEvents = ['load', 'error', 'scroll', 'resize'];
+export const DocumentEvents = ['load', 'error', 'scroll', 'resize', 'click'];

--- a/src/javascript/dom/position.js
+++ b/src/javascript/dom/position.js
@@ -67,7 +67,7 @@ class Position {
    * @param {Object} clientRectObject
    * @returns {Object}
    */
-  _clientRectToEnumerable(clientRectObject: Object): void {
+  _clientRectToEnumerable(clientRectObject: Object): Object {
     if (typeof clientRectObject === 'undefined') {
       throw new Error('ClientRect argument is undefined');
     }

--- a/src/javascript/dom/position.js
+++ b/src/javascript/dom/position.js
@@ -55,29 +55,8 @@ class Position {
         }
       }
     });
-    
+
     return result;
-  }
-
-  /**
-   * Set new position top and/or left to element. New postion will be taken into account
-   * only if element is absolute, relative or fixed positioned.
-   * @method set
-   * @param {Object} position
-   * @returns {Object}
-   */
-  set(position: Object = {}): void {
-    if (!position.hasOwnProperty('top') && !position.hasOwnProperty('left')) {
-      throw new Error('Position needs top or left or both keys to be applied');
-    }
-
-    if (position.hasOwnProperty('top')) {
-      this._from.style.top = position.top;
-    }
-
-    if (position.hasOwnProperty('left')) {
-      this._from.style.left = position.left;
-    }
   }
 
   /**

--- a/src/javascript/dom/position.js
+++ b/src/javascript/dom/position.js
@@ -44,7 +44,7 @@ class Position {
 
     const result = {};
     const fromDOMRect = this.get(this._from);
-    const relativeToDOMRect = relativeTo.getBoundingClientRect();
+    const relativeToDOMRect = this._clientRectToEnumerable(relativeTo.getBoundingClientRect());
 
     Object.keys(fromDOMRect).forEach((key) => {
       if (relativeToDOMRect.hasOwnProperty(key)) {
@@ -55,8 +55,29 @@ class Position {
         }
       }
     });
-
+    
     return result;
+  }
+
+  /**
+   * Set new position top and/or left to element. New postion will be taken into account
+   * only if element is absolute, relative or fixed positioned.
+   * @method set
+   * @param {Object} position
+   * @returns {Object}
+   */
+  set(position: Object = {}): void {
+    if (!position.hasOwnProperty('top') && !position.hasOwnProperty('left')) {
+      throw new Error('Position needs top or left or both keys to be applied');
+    }
+
+    if (position.hasOwnProperty('top')) {
+      this._from.style.top = position.top;
+    }
+
+    if (position.hasOwnProperty('left')) {
+      this._from.style.left = position.left;
+    }
   }
 
   /**

--- a/src/javascript/dom/position.js
+++ b/src/javascript/dom/position.js
@@ -26,7 +26,7 @@ class Position {
    * @returns {Object}
    */
   get(): Object {
-    return this._from.getBoundingClientRect();
+    return this._clientRectToEnumerable(this._from.getBoundingClientRect());
   }
 
   /**
@@ -47,12 +47,38 @@ class Position {
     const relativeToDOMRect = relativeTo.getBoundingClientRect();
 
     Object.keys(fromDOMRect).forEach((key) => {
-      if (relativeToDOMRect.hasOwnProperty(key) && key !== 'width' && key !== 'height') {
-        result[key] = fromDOMRect[key] - relativeToDOMRect[key];
+      if (relativeToDOMRect.hasOwnProperty(key)) {
+        if (key !== 'width' && key !== 'height') {
+          result[key] = fromDOMRect[key] - relativeToDOMRect[key];
+        } else {
+          result[key] = fromDOMRect[key];
+        }
       }
     });
 
     return result;
+  }
+
+  /**
+   * ClientRect object is not Enumerable, so we cannot use Object.keys to get its keys for looping
+   * This method returns an Enumerable object with same keys and values than client object passed
+   * by argument. Used by Position#get to returns same kind of object than relativeGet
+   * @method _clientRectToEnumerable
+   * @param {Object} clientRectObject
+   * @returns {Object}
+   */
+  _clientRectToEnumerable(clientRectObject: Object): void {
+    if (typeof clientRectObject === 'undefined') {
+      throw new Error('ClientRect argument is undefined');
+    }
+
+    const obj = {};
+
+    for (let key in clientRectObject) {
+      obj[key] = clientRectObject[key]
+    }
+
+    return obj;
   }
 }
 

--- a/test/javascript/test.position.js
+++ b/test/javascript/test.position.js
@@ -95,11 +95,21 @@ describe('Position', () => {
   /**
    * @test {Position#relativeGet}
    */
-  it("relativeGet doesn't take into account height/width relative element properties", () => {
+  it("relativeGet let height/width properties unmodified", () => {
     const position = new Position(sourceElement);
     const resultDOMRect = position.relativeGet();
 
-    assert.equal(resultDOMRect.width, sourceElement.width);
-    assert.equal(resultDOMRect.height, sourceElement.height);
+    assert.equal(resultDOMRect.width, sourceDOMRect.width);
+    assert.equal(resultDOMRect.height, sourceDOMRect.height);
+  });
+
+  /**
+   * @test {Position#_clientRectToEnumerable}
+   */
+  it("_clientRectToEnumerable throws exception '' if argument is undefined", () => {
+    const position = new Position(sourceElement);
+
+    assert.throws(() => position._clientRectToEnumerable(),
+      Error, 'ClientRect argument is undefined');
   });
 });


### PR DESCRIPTION
### What is the goal?

Allow us to create, show and close tooltips on demand.

- [ ] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [ ] The `README.md` has been updated accordingly
- [ ] **Issue:** https://jobandtalent.atlassian.net/browse/FRONT-168

### How is being implemented?

Available options:

- locator: String --> tooltip locator
- target: String --> trigger locator
- at (optional): String --> defines tooltip position relative to trigger. It can takes different values: "top left", "top center", "top right", "left top", "left center", "left bottom", "right top", "right center", "right bottom", "bottom left", "bottom center", "bottom right". If not defined, default at position will be "bottom left".
- gap (optional): number --> defines extra separation between trigger and tooltip. By default is 12.
- showOnce (optional): Boolean --> If true, tooltip will be shown once before being closed.
- showClose (optional): Boolean --> If true, shows a close element to hide tooltip. By default is false.
- position (optional): String --> Can take "absolute" or "fixed" as values. By default, "absolute". It allows us to fix our tooltip (not moving with scroll).

By default, arrow is positionated on the middle of shortest element. But if shortest element is trigger, will be placed on the middle only if middle position is between some defined values to avoid bad tooltip renders.

### Reviewers

@jobandtalent/frontend 
