### PR TITLE
Use i18n to show tooltip title

### DIFF
--- a/src/component/tooltip/template.html
+++ b/src/component/tooltip/template.html
@@ -3,7 +3,7 @@
     <i class="js_tooltip_arrow tooltip_arrow sprite"></i>
     <div class="tooltip_content_wrapper">
       <header class="tooltip_header">
-        <h1 class="tooltip_title"><%= name -%></h1>
+        <h1 class="tooltip_title"><%= t("tooltip.#{rel}.title") -%></h1>
         <%= link_to "#", class: "tooltip_close js_tooltip_close" do %>
           <span class="tooltip_close_text"><%= t("words.close") %></span>
           <i class="sprite sprite_tooltip_close"></i>


### PR DESCRIPTION
### What is the goal?

Use i18n to show tooltip title

- [ ] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [ ] The `README.md` has been updated accordingly
- [ ] **Issue:** (small PR's don't need it)

### How is being implemented?

Change name for i18n to show tooltip title

### Reviewers

@jobandtalent/frontend 

