### PR TITLE
Delayed Display pool

### DIFF
--- a/src/javascript/core/base.js
+++ b/src/javascript/core/base.js
@@ -21,6 +21,7 @@ require('core-js/modules/es6.array.map.js');
 require('core-js/modules/es6.array.index-of.js');
 require('core-js/modules/es6.function.bind.js');
 require('core-js/modules/es6.date.now');
+require('core-js/modules/es6.promise');
 
 // ModuleJS modules
 const ModuleJS = require('@lrsjng/modulejs');
@@ -30,6 +31,7 @@ const CookieStorage = require('../cookie-storage').default;
 const CloneObject = require('../clone-object').default;
 const Environment = require('../environment').default;
 const Position = require('../dom/position').default;
+const DelayedDisplayPool = require('../delayed-display-pool').default;
 
 // @see ../dom/builder
 ModuleJS.define('Builder/Factory', () => require('../dom/builder/factory').Factory);
@@ -43,6 +45,7 @@ ModuleJS.define('CookieStorage', () => CookieStorage);
 ModuleJS.define('CloneObject', () => CloneObject);
 ModuleJS.define('Environment', () => Environment);
 ModuleJS.define('Position', () => Position);
+ModuleJS.define('DelayedDisplayPool', () => DelayedDisplayPool);
 
 // Exposes the ModuleJS object in the global scope, that way
 // we can preserve compatibility with the current projects.

--- a/src/javascript/core/base.js
+++ b/src/javascript/core/base.js
@@ -17,6 +17,7 @@ require('core-js/modules/es6.array.for-each.js');
 require('core-js/modules/es6.array.filter.js');
 require('core-js/modules/es6.array.is-array.js');
 require('core-js/modules/es6.array.reduce.js');
+require('core-js/modules/es6.array.every');
 require('core-js/modules/es6.array.map.js');
 require('core-js/modules/es6.array.index-of.js');
 require('core-js/modules/es6.function.bind.js');

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -104,7 +104,8 @@ class DelayedDisplayPool {
    * @private
    */
   _isAnArrayOfObjects(components: Array<Object>): boolean {
-    return Array.isArray(components) && components.every(component => typeof component === 'object');
+    return Array.isArray(components) && components.length &&
+           components.every(component => typeof component === 'object');
   }
 }
 

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -27,7 +27,7 @@ class DelayedDisplayPool {
       throw new Error('ms has to be equals or bigger than 0 (ms)');
     }
 
-    if (Object.prototype.toString.call(components) !== '[object Array]') {
+    if (Array.isArray(components)) {
       throw new Error('components has to be an array of components');
     }
   }

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -3,7 +3,7 @@
 
 /**
  * Used for show/hide components sequencely
- * @module DisplayPool
+ * @module DelayedDisplayPool
  */
 class DelayedDisplayPool {
   _milliseconds: number;

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -37,15 +37,15 @@ class DelayedDisplayPool {
    * @public
    */
   start(): void {
-    var _this = this;
+    const self = this;
     this._components.reduce((promise, component) => {
       return promise.then(() => {
-        _this._showComponent(component);
-        return _this._delayClose(component);
+        self._showComponent(component);
+        return self._delayClose(component);
       }, (error) => {
         throw new Error(error);
       });
-    }, _this.$.Deferred().resolve());
+    }, self.$.Deferred().resolve());
   }
 
   /**
@@ -81,16 +81,16 @@ class DelayedDisplayPool {
    */
   _delayClose(component: Object): Object {
     const deferred = this.$.Deferred();
-    const _this = this;
+    const self = this;
 
     setTimeout(() => {
       try {
-        _this._closeComponent(component);
+        self._closeComponent(component);
       } catch (error) {
         deferred.reject(error);
       }
       deferred.resolve();
-    }, _this._milliseconds);
+    }, self._milliseconds);
 
     return deferred.promise();
   }

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -15,21 +15,23 @@ class DelayedDisplayPool {
    * @constructor
    */
   constructor(milliseconds = 0, components: Array<Object>) {
-    this._milliseconds = milliseconds;
-    this._components = components;
     this.$ = require('./dom/core');
 
-    if (typeof this._milliseconds !== 'number') {
+    if (typeof milliseconds !== 'number') {
       throw new Error('ms has to be a number');
     }
 
-    if (this._milliseconds < 0) {
+    if (milliseconds < 0) {
       throw new Error('ms has to be equals or bigger than 0 (ms)');
     }
+
+    this._milliseconds = milliseconds;
 
     if (Array.isArray(components)) {
       throw new Error('components has to be an array of components');
     }
+
+    this._components = components;
   }
 
   /**

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -1,0 +1,99 @@
+/* @flow */
+'use strict';
+
+/**
+ * Used for show/hide components sequencely
+ * @module DisplayPool
+ */
+class DelayedDisplayPool {
+  _ms: number;
+  _components: Array;
+
+  /**
+   * @param {number} ms
+   * @param {Array} components
+   * @constructor
+   */
+  constructor(ms = 0, components: Array<Object>) {
+    this._ms = ms;
+    this._components = components;
+    this.$ = require('./dom/core');
+
+    if (typeof this._ms !== 'number') {
+      throw new Error('ms has to be a number');
+    }
+
+    if (this._ms < 0) {
+      throw new Error('ms has to be equals or bigger than 0 (ms)');
+    }
+
+    if (Object.prototype.toString.call(components) !== '[object Array]') {
+      throw new Error('components has to be an array of components');
+    }
+  }
+
+  /**
+   * @method start
+   * @public
+   */
+  start(): void {
+    var _this = this;
+    this._components.reduce((promise, component) => {
+      return promise.then(() => {
+        _this._showComponent(component);
+        return _this._delayClose(component);
+      }, (error) => {
+        throw new Error(error);
+      });
+    }, _this.$.Deferred().resolve());
+  }
+
+  /**
+   * @param {Object} component
+   * @method _showComponent
+   * @private
+   */
+  _showComponent(component: Object): void {
+    if (typeof component.show !== 'function') {
+      throw new Error("component doesn't respond to show method");
+    } else {
+      component.show();
+    }
+  }
+
+  /**
+   * @param {Object} component
+   * @method _closeComponent
+   * @private
+   */
+  _closeComponent(component: Object): void {
+    if (typeof component.close !== 'function') {
+      throw new Error("component doesn't respond to close method");
+    } else {
+      component.close();
+    }
+  }
+
+  /**
+   * @param {component} ms
+   * @method _closeComponent
+   * @private
+   */
+  _delayClose(component: Object): Object {
+    const deferred = this.$.Deferred();
+    const _this = this;
+
+    setTimeout(() => {
+      try {
+        _this._closeComponent(component);
+      } catch (error) {
+        deferred.reject(error);
+      }
+      deferred.resolve();
+    }, _this._ms);
+
+    return deferred.promise();
+  }
+}
+
+export default DelayedDisplayPool;

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -6,7 +6,7 @@
  * @module DisplayPool
  */
 class DelayedDisplayPool {
-  _ms: number;
+  _milliseconds: number;
   _components: Array;
 
   /**
@@ -14,16 +14,16 @@ class DelayedDisplayPool {
    * @param {Array} components
    * @constructor
    */
-  constructor(ms = 0, components: Array<Object>) {
-    this._ms = ms;
+  constructor(milliseconds = 0, components: Array<Object>) {
+    this._milliseconds = milliseconds;
     this._components = components;
     this.$ = require('./dom/core');
 
-    if (typeof this._ms !== 'number') {
+    if (typeof this._milliseconds !== 'number') {
       throw new Error('ms has to be a number');
     }
 
-    if (this._ms < 0) {
+    if (this._milliseconds < 0) {
       throw new Error('ms has to be equals or bigger than 0 (ms)');
     }
 
@@ -90,7 +90,7 @@ class DelayedDisplayPool {
         deferred.reject(error);
       }
       deferred.resolve();
-    }, _this._ms);
+    }, _this._milliseconds);
 
     return deferred.promise();
   }

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -10,7 +10,7 @@ class DelayedDisplayPool {
   _components: Array;
 
   /**
-   * @param {number} ms
+   * @param {number} milliseconds
    * @param {Array} components
    * @constructor
    */
@@ -18,11 +18,11 @@ class DelayedDisplayPool {
     this.$ = require('./dom/core');
 
     if (typeof milliseconds !== 'number') {
-      throw new Error('ms has to be a number');
+      throw new Error('milliseconds has to be a number');
     }
 
     if (milliseconds < 0) {
-      throw new Error('ms has to be equals or bigger than 0 (ms)');
+      throw new Error('milliseconds has to be equals or bigger than 0 (milliseconds)');
     }
 
     this._milliseconds = milliseconds;
@@ -77,7 +77,7 @@ class DelayedDisplayPool {
   }
 
   /**
-   * @param {component} ms
+   * @param {component} component
    * @method _closeComponent
    * @private
    */

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -27,7 +27,7 @@ class DelayedDisplayPool {
 
     this._milliseconds = milliseconds;
 
-    if (Array.isArray(components)) {
+    if (!this._isAnArrayOfObjects(components)) {
       throw new Error('components has to be an array of components');
     }
 
@@ -47,7 +47,7 @@ class DelayedDisplayPool {
       }, (error) => {
         throw new Error(error);
       });
-    }, self.$.Deferred().resolve());
+    }, Promise.resolve());
   }
 
   /**
@@ -82,19 +82,22 @@ class DelayedDisplayPool {
    * @private
    */
   _delayClose(component: Object): Object {
-    const deferred = this.$.Deferred();
     const self = this;
 
-    setTimeout(() => {
-      try {
-        self._closeComponent(component);
-      } catch (error) {
-        deferred.reject(error);
-      }
-      deferred.resolve();
-    }, self._milliseconds);
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        try {
+          self._closeComponent(component);
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      }, self._milliseconds);
+    });
+  }
 
-    return deferred.promise();
+  _isAnArrayOfObjects(components): boolean {
+    return Array.isArray(components) && components.every(component => typeof component === 'object');
   }
 }
 

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -79,6 +79,7 @@ class DelayedDisplayPool {
   /**
    * @param {Object} component
    * @method _delayClose
+   * @returns {Object}
    * @private
    */
   _delayClose(component: Object): Object {
@@ -99,6 +100,7 @@ class DelayedDisplayPool {
   /**
    * @param {Array} components
    * @method _isAnArrayOfObjects
+   * @returns {boolean}
    * @private
    */
   _isAnArrayOfObjects(components: Array<Object>): boolean {

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -78,7 +78,7 @@ class DelayedDisplayPool {
 
   /**
    * @param {component} component
-   * @method _closeComponent
+   * @method _delayClose
    * @private
    */
   _delayClose(component: Object): Object {

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -96,7 +96,7 @@ class DelayedDisplayPool {
     });
   }
 
-  _isAnArrayOfObjects(components): boolean {
+  _isAnArrayOfObjects(components: Array<Object>): boolean {
     return Array.isArray(components) && components.every(component => typeof component === 'object');
   }
 }

--- a/src/javascript/delayed-display-pool.js
+++ b/src/javascript/delayed-display-pool.js
@@ -77,7 +77,7 @@ class DelayedDisplayPool {
   }
 
   /**
-   * @param {component} component
+   * @param {Object} component
    * @method _delayClose
    * @private
    */
@@ -96,6 +96,11 @@ class DelayedDisplayPool {
     });
   }
 
+  /**
+   * @param {Array} components
+   * @method _isAnArrayOfObjects
+   * @private
+   */
   _isAnArrayOfObjects(components: Array<Object>): boolean {
     return Array.isArray(components) && components.every(component => typeof component === 'object');
   }

--- a/test/javascript/test.delayed-display-pool.js
+++ b/test/javascript/test.delayed-display-pool.js
@@ -1,0 +1,119 @@
+'use strict';
+
+import assert from 'assert';
+import jsdom from 'mocha-jsdom';
+import DelayedDisplayPool from '../../src/javascript/delayed-display-pool';
+import Spy from '../../src/javascript/test-framework/spy';
+
+/**
+ * @test {DelayedDisplayPool}
+ */
+describe('DelayedDisplayPool', () => {
+  // Initialize the fake DOM that jsdom exposes
+  jsdom();
+
+  /**
+   * @test {DelayedDisplayPool#constructor}
+   */
+  it("It throws exception 'milliseconds has to be a number' if milliseconds argument" +
+     "is not a number", () => {
+    assert.throws(() => new DelayedDisplayPool('test', []),
+      Error, 'milliseconds has to be a number');
+  });
+
+  /**
+   * @test {DelayedDisplayPool#constructor}
+   */
+  it("It throws exception 'milliseconds has to be equals or bigger than 0 (milliseconds)' " +
+     "if milliseconds argument is smaller than 0", () => {
+    assert.throws(() => new DelayedDisplayPool(-1, []),
+      Error, 'milliseconds has to be equals or bigger than 0 (milliseconds)');
+  });
+
+  /**
+   * @test {DelayedDisplayPool#constructor}
+   */
+  it("It throws exception 'components has to be an array of components' " +
+     "if components argument is not an array of objects", () => {
+    assert.throws(() => new DelayedDisplayPool(1, 'test'),
+      Error, 'components has to be an array of components');
+    assert.throws(() => new DelayedDisplayPool(1, 12),
+      Error, 'components has to be an array of components');
+    assert.throws(() => new DelayedDisplayPool(1, []),
+      Error, 'components has to be an array of components');
+    assert.throws(() => new DelayedDisplayPool(1, () => {}),
+      Error, 'components has to be an array of components');
+    assert.throws(() => new DelayedDisplayPool(1, ['test']),
+      Error, 'components has to be an array of components');
+    assert.throws(() => new DelayedDisplayPool(1, [12]),
+      Error, 'components has to be an array of components');
+    assert.throws(() => new DelayedDisplayPool(1, [() => {}]),
+      Error, 'components has to be an array of components');
+  });
+
+  /**
+   * @test {DelayedDisplayPool#_showComponent}
+   */
+  it("show method has to be called if defined for a component", (done) =>  {
+    const fakeComponent = { show: () => {
+      done();
+    }};
+
+    const delayedPool = new DelayedDisplayPool(10, [fakeComponent]);
+    delayedPool._showComponent(fakeComponent);
+  });
+
+  /**
+   * @test {DelayedDisplayPool#_closeComponent}
+   */
+  it("It throws exception 'component doesn\'t respond to close method' if component " +
+     "doesn't respond to close", () =>  {
+    const delayedPool = new DelayedDisplayPool(10, [{}]);
+
+    assert.throws(() => delayedPool._closeComponent(),
+      Error, 'component doesn\'t respond to close method');
+  });
+
+  /**
+   * @test {DelayedDisplayPool#_closeComponent}
+   */
+  it("show method has to be called if defined for a component", (done) =>  {
+    const fakeComponent = {
+      show: () => {},
+      close: () => {
+        done();
+      }
+    };
+
+    var delayedPool = new DelayedDisplayPool(10, [fakeComponent]);
+    delayedPool._closeComponent(fakeComponent);
+  });
+
+  /**
+   * @test {DelayedDisplayPool#start}
+   */
+  it("It shows and close components sequencely", (done) =>  {
+    const fakeComponent1 = {
+      show: () => {},
+      close: () => {}
+    };
+
+    const fakeComponent2 = {
+      show: () => {},
+      close: () => {
+        done();
+      }
+    };
+
+    var delayedPool = new DelayedDisplayPool(10, [fakeComponent1, fakeComponent2]);
+    delayedPool.start();
+  });
+
+  /**
+   * @test {DelayedDisplayPool#_isAnArrayOfObjects}
+   */
+  it("_isAnArrayOfObjects returns true if an array of objects is passed as argument", () => {
+    const components = [{}];
+    assert.ok((new DelayedDisplayPool(1, components)._isAnArrayOfObjects(components)));
+  });
+});

--- a/test/javascript/test.delayed-display-pool.js
+++ b/test/javascript/test.delayed-display-pool.js
@@ -3,7 +3,6 @@
 import assert from 'assert';
 import jsdom from 'mocha-jsdom';
 import DelayedDisplayPool from '../../src/javascript/delayed-display-pool';
-import Spy from '../../src/javascript/test-framework/spy';
 
 /**
  * @test {DelayedDisplayPool}


### PR DESCRIPTION
### What is the goal?

Show and hide sequentially an list of components.

- [ ] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [ ] The `README.md` has been updated accordingly
- [ ] **Issue:** (small PR's don't need it)

### How is being implemented?

To show and hide sequentially the list of components we have used jQuery promises. We show the first one and then, when its closed after a while we send a resolved promise to start with the next one.

Example:
```
var pool = new DelayedDisplayPool(3000, [component1, component2];
pool.start();
```

### Reviewers

@jobandtalent/frontend 

