### PR TITLE
Remove unnecessary method and set new cookie name

### DIFF
--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -16,7 +16,7 @@ class TooltipController extends BaseController {
     options.id = 'Tooltip'; // eslint-disable-line no-param-reassign
     super(options);
     this._showOnce = this._options.showOnce || false;
-    this._cookieId = this._setCookieName(this._options.locator);
+    this._cookieId = this._getCookieName(this._options.locator);
   }
 
   /**
@@ -47,10 +47,10 @@ class TooltipController extends BaseController {
 
   /**
    * @param {string} locator
-   * @method _setCookieName
+   * @method _getCookieName
    * @private
    */
-  _setCookieName(locator: string): string {
+  _getCookieName(locator: string): string {
     return locator.replace(/[_\W]+/g, "_");
   }
 }

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -16,7 +16,7 @@ class TooltipController extends BaseController {
     options.id = 'Tooltip'; // eslint-disable-line no-param-reassign
     super(options);
     this._showOnce = this._options.showOnce || false;
-    this._cookieId = this._options.locator;
+    this._cookieId = this._setCookieName(this._options.locator);
   }
 
   /**
@@ -43,6 +43,15 @@ class TooltipController extends BaseController {
   close(): void {
     this._store.dispatch({ type: 'close' });
     this._eventBus.publish(`close${this._id}`, { locator: this._options.locator });
+  }
+
+  /**
+   * @param {string} locator
+   * @method _setCookieName
+   * @private
+   */
+  _setCookieName(locator: string): string {
+    return locator.replace(/[_\W]+/g, "_");
   }
 }
 

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -97,23 +97,13 @@ class TooltipView extends BaseView {
    */
   _positionate(): void {
     this._appendToBody();
-    this._setCSSPosition();
+    this._tooltip.style.position = this._position;
     this._orientateArrow();
     this._computePosition();
     this._addExtraOffset();
     this._positionateTop(this._top);
     this._positionateLeft(this._left);
     this._positionateArrow();
-  }
-
-  /**
-   * @method _setCSSPosition
-   * @private
-   */
-  _setCSSPosition(): void {
-    if (this._position !== this._defaultPosition) {
-      this._tooltip.style.position = this._position;
-    }
   }
 
   /**


### PR DESCRIPTION
### What is the goal?

Remove unnecessary method from Tooltip

- [ ] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [ ] The `README.md` has been updated accordingly
- [ ] **Issue:** (small PR's don't need it)

### How is being implemented?

Remove setCSSPosition method from view and set a different cookie name to remove weird simbols

### Reviewers

@jobandtalent/frontend 

