### PR TITLE
Replace js-cookie for a js-cookie fork which solves es6 babel transpiler error

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "html-webpack-plugin": "^2.16.0",
     "html5shiv": "^3.7.3",
     "jquery": "^1.12.4",
-    "js-cookie": "^2.1.2",
+    "@tomasperezv/js-cookie": "^2.1.2",
     "less": "^2.6.1",
     "less-loader": "^2.2.3",
     "mocha": "^2.4.5",


### PR DESCRIPTION
### What is the goal?

Solves es6 babel transpiler error related with CookieStorage

- [ ] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [ ] The `README.md` has been updated accordingly
- [ ] **Issue:** (small PR's don't need it)

### How is being implemented?

Replace js-cookie for a js-cookie fork which solves es6 babel transpiler error

### Reviewers

@jobandtalent/frontend 