### PR TITLE
Remove set cookie on Tooltip

### DIFF
--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -26,7 +26,6 @@ class TooltipController extends BaseController {
   show(): void {
     if (this._showOnce) {
       if (CookieStorage.get(this._cookieId) !== 'yes') {
-        CookieStorage.set(this._cookieId, 'yes', { expires: 9999 });
         this._store.dispatch({ type: 'show' });
         this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
       }
@@ -51,7 +50,7 @@ class TooltipController extends BaseController {
    * @private
    */
   _getCookieName(locator: string): string {
-    return locator.replace(/[_\W]+/g, "_");
+    return locator.replace(/[_\W]+/g, '_');
   }
 }
 


### PR DESCRIPTION
### What is the goal?

Remove set cookie on tooltip. This will rely temporally to bind event of show tooltip.

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

Remove Cookie.set call

### Reviewers

@jobandtalent/frontend 