### PR TITLE
Tooltip close only applies to tooltip which contains that close itself

### DIFF
--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -83,7 +83,7 @@ class TooltipView extends BaseView {
     var clickedElement = event.target;
     const closeElementClass = this.locators.closeElement.substring(1);
 
-    if (this._tooltip.hasChildNodes(clickedElement) &&
+    if (this._tooltip.contains(clickedElement) &&
         (clickedElement.className.indexOf(closeElementClass) !== -1 ||
          clickedElement.parentElement.className.indexOf(closeElementClass) !== -1)) {
       this.close();


### PR DESCRIPTION
### What is the goal?

Solve a bug currently we have on tooltips. Tooltips closing action should only applies to the tooltip itself, not all of them.

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

`hasChildNodes` is not what we need. `hasChildNodes` doesn't accept any argument. It's only used to know if a node has childrens. `contains` is what we were looking for.

### Reviewers

@jobandtalent/frontend 

