### PR TITLE
Avoid preventDefault true if locator is document

### DIFF
--- a/src/javascript/component/base/event-actions.js
+++ b/src/javascript/component/base/event-actions.js
@@ -101,7 +101,7 @@ class EventActions {
           }
         }
 
-        let preventDefault = this._getPreventDefault(locator);
+        const preventDefault = this._getPreventDefault(locator);
 
         if (locator !== null && typeof locator === 'object' &&
             typeof locator.__set__ === 'undefined') {

--- a/src/javascript/component/base/event-actions.js
+++ b/src/javascript/component/base/event-actions.js
@@ -84,53 +84,56 @@ class EventActions {
       const eventName = events[i];
       for (const locatorName in locators) { // eslint-disable-line guard-for-in
         const locator = locators[locatorName];
-        let eventListenerName = this._getEventListenerName(eventName, locatorName);
-        let element;
 
-        if (locator === document || locator.id === document) {
-          element = document;
-          eventListenerName = eventListenerName.replace('Document', '');
-        } else {
-          let locatorAsString = this._getLocatorString(locator);
-          if (typeof locatorAsString !== 'undefined') {
-            if (typeof locators.wrapper !== 'undefined') {
-              locatorAsString = `${locators.wrapper} ${locatorAsString}`;
-            }
+        if (locator !== null) {
+          let eventListenerName = this._getEventListenerName(eventName, locatorName);
+          let element;
 
-            element = document.querySelector(locatorAsString);
-          }
-        }
-
-        const preventDefault = this._getPreventDefault(locator);
-
-        if (locator !== null && typeof locator === 'object' &&
-            typeof locator.__set__ === 'undefined') {
-          // Views can avoid having to define the listeners methods by using object locators,
-          // that way we support passing simple state changes view -> controller -> dispatcher -> view
-          /* eslint-disable no-param-reassign */
-          if (typeof locator.handler === 'function') {
-            // $FlowFixMe: Review Indexable property not found
-            target[eventListenerName] = locator.handler;
+          if (locator === document || locator.id === document) {
+            element = document;
+            eventListenerName = eventListenerName.replace('Document', '');
           } else {
-            // Empty event handler for simple message passing
-            // $FlowFixMe: Review Indexable property not found
-            target[eventListenerName] = () => {};
+            let locatorAsString = this._getLocatorString(locator);
+            if (typeof locatorAsString !== 'undefined') {
+              if (typeof locators.wrapper !== 'undefined') {
+                locatorAsString = `${locators.wrapper} ${locatorAsString}`;
+              }
+
+              element = document.querySelector(locatorAsString);
+            }
           }
-          /* eslint-enable no-param-reassign */
 
-          locator.__set__ = true;
-        }
+          const preventDefault = this._getPreventDefault(locator);
 
-        // $FlowFixMe: Indexable signature not found
-        if (typeof target[eventListenerName] === 'function') {
-          callback({
-            element,
-            eventName,
-            eventListenerName,
-            eventHandler: target[eventListenerName].bind(target),
-            locatorName,
-            preventDefault
-          });
+          if (locator !== null && typeof locator === 'object' &&
+              typeof locator.__set__ === 'undefined') {
+            // Views can avoid having to define the listeners methods by using object locators,
+            // that way we support passing simple state changes view -> controller -> dispatcher -> view
+            /* eslint-disable no-param-reassign */
+            if (typeof locator.handler === 'function') {
+              // $FlowFixMe: Review Indexable property not found
+              target[eventListenerName] = locator.handler;
+            } else {
+              // Empty event handler for simple message passing
+              // $FlowFixMe: Review Indexable property not found
+              target[eventListenerName] = () => {};
+            }
+            /* eslint-enable no-param-reassign */
+
+            locator.__set__ = true;
+          }
+
+          // $FlowFixMe: Indexable signature not found
+          if (typeof target[eventListenerName] === 'function') {
+            callback({
+              element,
+              eventName,
+              eventListenerName,
+              eventHandler: target[eventListenerName].bind(target),
+              locatorName,
+              preventDefault
+            });
+          }
         }
       }
     }
@@ -145,7 +148,7 @@ class EventActions {
   _getPreventDefault(locator: Object|string): boolean {
     let preventDefault = false;
 
-    if (locator !== document && locator.id !== document) {
+    if (locator !== null && locator !== document && locator.id !== document) {
       preventDefault = typeof locator.preventDefault !== 'undefined' ? locator.preventDefault : true;
     }
 

--- a/src/javascript/component/base/event-actions.js
+++ b/src/javascript/component/base/event-actions.js
@@ -84,21 +84,25 @@ class EventActions {
       const eventName = events[i];
       for (const locatorName in locators) { // eslint-disable-line guard-for-in
         const locator = locators[locatorName];
-        let locatorAsString = this._getLocatorString(locator);
         let eventListenerName = this._getEventListenerName(eventName, locatorName);
         let element;
-        if (locator === document) {
+
+        if (locator === document || locator.id === document) {
           element = document;
           eventListenerName = eventListenerName.replace('Document', '');
-        } else if (typeof locatorAsString !== 'undefined') {
-          if (typeof locators.wrapper !== 'undefined') {
-            locatorAsString = `${locators.wrapper} ${locatorAsString}`;
-          }
+        } else {
+          let locatorAsString = this._getLocatorString(locator);
+          if (typeof locatorAsString !== 'undefined') {
+            if (typeof locators.wrapper !== 'undefined') {
+              locatorAsString = `${locators.wrapper} ${locatorAsString}`;
+            }
 
-          element = document.querySelector(locatorAsString);
+            element = document.querySelector(locatorAsString);
+          }
         }
 
-        let preventDefault = true;
+        let preventDefault = this._getPreventDefault(locator);
+
         if (locator !== null && typeof locator === 'object' &&
             typeof locator.__set__ === 'undefined') {
           // Views can avoid having to define the listeners methods by using object locators,
@@ -115,7 +119,6 @@ class EventActions {
           /* eslint-enable no-param-reassign */
 
           locator.__set__ = true;
-          preventDefault = locator.preventDefault || true;
         }
 
         // $FlowFixMe: Indexable signature not found
@@ -131,6 +134,22 @@ class EventActions {
         }
       }
     }
+  }
+
+  /**
+   * @param {Object|string} locator
+   * @returns {Boolean}
+   * @method _getPreventDefault
+   * @private
+   */
+  _getPreventDefault(locator: Object|string): boolean {
+    let preventDefault = false;
+
+    if (locator !== document && locator.id !== document) {
+      preventDefault = typeof locator.preventDefault !== 'undefined' ? locator.preventDefault : true;
+    }
+
+    return preventDefault;
   }
 
   /**

--- a/src/javascript/component/base/event-actions.js
+++ b/src/javascript/component/base/event-actions.js
@@ -105,7 +105,7 @@ class EventActions {
 
           const preventDefault = this._getPreventDefault(locator);
 
-          if (locator !== null && typeof locator === 'object' &&
+          if (typeof locator === 'object' &&
               typeof locator.__set__ === 'undefined') {
             // Views can avoid having to define the listeners methods by using object locators,
             // that way we support passing simple state changes view -> controller -> dispatcher -> view


### PR DESCRIPTION
### What is the goal?

Solve preventDefault true on a document event.

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

Currently if we add a locator as document, preventDefault was setted to true. With this modification we set by default to false, and if locator is not a document and has preventDefault defined, we assign it as value of preventDefault.

### Reviewers

@jobandtalent/frontend 

