### PR TITLE
Allowing open and close more than one popup at once

### DIFF
--- a/src/component/popup/popup-controller.coffee
+++ b/src/component/popup/popup-controller.coffee
@@ -3,13 +3,19 @@
 BaseController = require('../../javascript/component/base/base-controller').default
 
 class PopupController extends BaseController
+  # @method constructor
+  # @param {Object} options
   constructor: (options) ->
     options.id = 'Popup'
     super(options)
 
+  # @method show
+  # @public
   show: ->
     @_store.dispatch({ type: 'show' })
 
+  # @method close
+  # @public
   close: ->
     @_store.dispatch({ type: 'close' })
 

--- a/src/component/popup/popup-view.coffee
+++ b/src/component/popup/popup-view.coffee
@@ -5,25 +5,25 @@ Overlay = require('../overlay/overlay-controller.coffee').default
 require('!style!css!less!./main.less')
 
 class PopupView extends BaseView
-
-  locators:
-    main: '#popup'
-    close:
-      id: '[data-where=close_modal]'
-      event: 'click'
-    show:
-      id: '[data-where=trigger]'
-      event: 'click'
-    header: '.m_popup_with_header'
-
+  # @method constructor
+  # @param {Object} options
   constructor: (options) ->
+    @locators =
+      close:
+        id: options.locator + " [data-where='close_modal']"
+        event: 'click'
+      show: options.locator + " [data-where='trigger']"
+      header: '.m_popup_with_header'
+
     super(options)
 
-    @element = @$(@locators.main)
+    @element = @$(options.locator)
     if @element.data('modal')
       @overlay = new Overlay()
 
-  show: () =>
+  # @method show
+  # @public
+  show: =>
     if @element.hasClass 'hidden'
       @element.removeClass 'hidden'
       @$('body').css 'overflow', 'hidden'
@@ -32,7 +32,9 @@ class PopupView extends BaseView
 
     if @overlay? then @overlay.show(true)
 
-  close: () =>
+  # @method close
+  # @public
+  close: =>
     @element.addClass 'hidden'
     @$('body').css 'overflow', 'visible'
 

--- a/src/html/sandbox/css.html
+++ b/src/html/sandbox/css.html
@@ -14,11 +14,11 @@
     <section>
       <h3>Components</h3>
       <span class="bold">Popup</span>
-      <div id="popup" class="hidden">
-        <div class="m_popup m_popup_with_header hidden" data-trigger="trigger" data-where="where">
+      <div id="popup-1" class="hidden">
+        <div class="m_popup m_popup_with_header hidden" data-trigger="trigger">
           <div class="m_popup_with_header_header">
             <a href="#" data-where="close_modal"><small>Cerrar</small></a>
-            <span>Popup header</span>
+            <span>Popup header 1</span>
           </div>
           <div class="m_popup_with_header_content">
             <div class="m_popup_with_header_content_block">
@@ -27,7 +27,23 @@
           </div>
         </div>
       </div>
-      <a href="#" id="popup-example">Trigger link</a>
+      <a href="#" id="popup-example-1">Trigger link 1</a>
+
+      <div id="popup-2" class="hidden">
+        <div class="m_popup m_popup_with_header hidden" data-trigger="trigger">
+          <div class="m_popup_with_header_header">
+            <a href="#" data-where="close_modal"><small>Cerrar</small></a>
+            <span>Popup header 2</span>
+          </div>
+          <div class="m_popup_with_header_content">
+            <div class="m_popup_with_header_content_block">
+              Popup content
+            </div>
+          </div>
+        </div>
+      </div>
+      <a href="#" id="popup-example-2">Trigger link 2</a>
+
       <div id="cookie_consent_box"></div>
       <div id="form"></div>
       <script id="dom-builder-form" type="text/template">
@@ -56,8 +72,13 @@
           var Loader = modulejs.require('LoaderController');
           var Trigger = modulejs.require('TriggerController');
           var loader = new Loader(
-            [{ id: 'Popup', locator: '#popup',  action: 'show' }],
-            new Trigger({ locator: '#popup-example' })
+            [{ id: 'Popup', locator: '#popup-1',  action: 'show' }],
+            new Trigger({ locator: '#popup-example-1' })
+          );
+
+          var loader2 = new Loader(
+            [{ id: 'Popup', locator: '#popup-2', action: 'show' }],
+            new Trigger({ locator: '#popup-example-2' })
           );
 
           var CookieConsent = modulejs.require('CookieConsentController');


### PR DESCRIPTION
### What is the goal?

Allow us to open and close different popups on the page.

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

I found an inconvenience with current Popup implementation. If we added two or more popups, close event wasn't working properly. With this modification, close event is handle it properly, also show.

I also included some documentation for current methods.

## Caveats

It's worth to highlight the use of Loader + Trigger + Popup as we can see on the sandbox, to take into account for future usage.

```javascript
var loader = new Loader([{ id: 'Popup', locator: '#popup-1',  action: 'show' }],
                        new Trigger({ locator: '#popup-example-1' })
);
````

Like this we get that clicking on `#popup-example-1` link triggers show action from Popup.

### Reviewers

@jobandtalent/frontend

