### PR TITLE
Setting cookie tooltip to yes after a show

### DIFF
--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -26,6 +26,7 @@ class TooltipController extends BaseController {
   show(): void {
     if (this._showOnce) {
       if (CookieStorage.get(this._cookieId) !== 'yes') {
+        CookieStorage.set(this._cookieId, 'yes', { expires: 9999 });
         this._store.dispatch({ type: 'show' });
         this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
       }


### PR DESCRIPTION
### What is the goal?

Setting cookie tooltip to 'yes' if we have to show it only once

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

Just adding CookieStorage.set call in the correct place.

### Reviewers

@jobandtalent/frontend 

