### PR TITLE
Tooltip improvements

### DIFF
--- a/src/component/tooltip/template.html
+++ b/src/component/tooltip/template.html
@@ -3,7 +3,7 @@
     <i class="js_tooltip_arrow tooltip_arrow sprite"></i>
     <div class="tooltip_content_wrapper">
       <header class="tooltip_header">
-        <h1 class="tooltip_title"><%= t("tooltip.#{rel}.title") -%></h1>
+        <h1 class="tooltip_title"><%= t("#{rel}.tooltip_title") -%></h1>
         <%= link_to "#", class: "tooltip_close js_tooltip_close" do %>
           <span class="tooltip_close_text"><%= t("words.close") %></span>
           <i class="sprite sprite_tooltip_close"></i>

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -103,6 +103,7 @@ class TooltipView extends BaseView {
     this._positionateTop(this._top);
     this._positionateLeft(this._left);
     this._positionateArrow();
+    this._tooltip.style.display = 'none';
   }
 
   /**


### PR DESCRIPTION
### What is the goal?

Currently tooltips have opacity 0, but are visible on document. So they can overlap other elements causing inconvenients.

We have changed i18n namespace, to get correct wordings.

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

I set display none for every tooltip after being positioned.

I have changed i18n on the tooltip template.

### Reviewers

@jobandtalent/frontend 
