### PR TITLE
Fix close event to avoid bad behaviour when clicking on document

### DIFF
--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -23,8 +23,7 @@ class TooltipView extends BaseView {
   constructor(options: Object) {
     options.locators = { // eslint-disable-line no-param-reassign
       arrow: '.js_tooltip_arrow',
-      closeElement: '.js_tooltip_close',
-      closeTooltip: document
+      closeTooltip: '.js_tooltip_close'
     };
     super(options);
 
@@ -48,13 +47,14 @@ class TooltipView extends BaseView {
     this._showClose = this._controller._options.showClose || false;
 
     if (!this._showClose) {
-      this._tooltip.querySelector(this.locators.closeElement).remove();
+      this._tooltip.querySelector(this.locators.closeTooltip).remove();
     }
 
     this._top = 0;
     this._left = 0;
 
     this._positionate();
+    this._initEvents();
   }
 
   /**
@@ -75,18 +75,22 @@ class TooltipView extends BaseView {
   }
 
   /**
-   * @param {Object} event
-   * @method onClick
-   * @public
+   * @method _initEvents
+   * @private
    */
-  onClick(event: Object): void {
-    var clickedElement = event.target;
-    const closeElementClass = this.locators.closeElement.substring(1);
+  _initEvents(): void {
+    const self = this;
+    const closeElement = this._tooltip.querySelector(this.locators.closeTooltip);
+    if (closeElement !== null ) {
+      closeElement.addEventListener('click', function(event) {
+        const clickedElement = event.target;
+        const closeElementClass = self.locators.closeTooltip.substring(1);
 
-    if (this._tooltip.contains(clickedElement) &&
-        (clickedElement.className.indexOf(closeElementClass) !== -1 ||
-         clickedElement.parentElement.className.indexOf(closeElementClass) !== -1)) {
-      this.close();
+        if (clickedElement.className.indexOf(closeElementClass) !== -1 ||
+            clickedElement.parentElement.className.indexOf(closeElementClass) !== -1) {
+          self.close();
+        }
+      });
     }
   }
 

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -81,8 +81,8 @@ class TooltipView extends BaseView {
   _initEvents(): void {
     const self = this;
     const closeElement = this._tooltip.querySelector(this.locators.closeTooltip);
-    if (closeElement !== null ) {
-      closeElement.addEventListener('click', function(event) {
+    if (closeElement !== null) {
+      closeElement.addEventListener('click', (event) => {
         const clickedElement = event.target;
         const closeElementClass = self.locators.closeTooltip.substring(1);
 


### PR DESCRIPTION
### What is the goal?

Currently we have a problem if we add a tooltip with close element. It prevents to click over anything on the page. This PR is a fix to ensure click on the close element works perfectly, also on the rest of the page.

- [ ] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [ ] The `README.md` has been updated accordingly
- [ ] **Issue:** (small PR's don't need it)

### How is being implemented?

I removed closeElement and closeTooltip locators, and add an `_initEvents` method to attach manually the click event on the close element.

### Reviewers

@jobandtalent/frontend 

