### PR TITLE
Tooltips should dispatch a state change when click on close element

### DIFF
--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -88,7 +88,8 @@ class TooltipView extends BaseView {
 
         if (clickedElement.className.indexOf(closeElementClass) !== -1 ||
             clickedElement.parentElement.className.indexOf(closeElementClass) !== -1) {
-          self.close();
+          this._controller.close();
+          this.close();
         }
       });
     }

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -89,7 +89,6 @@ class TooltipView extends BaseView {
         if (clickedElement.className.indexOf(closeElementClass) !== -1 ||
             clickedElement.parentElement.className.indexOf(closeElementClass) !== -1) {
           self._controller.close();
-          self.close();
         }
       });
     }

--- a/src/component/tooltip/tooltip-view.js
+++ b/src/component/tooltip/tooltip-view.js
@@ -88,8 +88,8 @@ class TooltipView extends BaseView {
 
         if (clickedElement.className.indexOf(closeElementClass) !== -1 ||
             clickedElement.parentElement.className.indexOf(closeElementClass) !== -1) {
-          this._controller.close();
-          this.close();
+          self._controller.close();
+          self.close();
         }
       });
     }


### PR DESCRIPTION
### What is the goal?

Dispatch a state change when click on close element

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

Adding a call to close method from controller

### Reviewers

@jobandtalent/frontend 
