### PR TITLE
Avoid close if a tooltip is already closed

### DIFF
--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -17,6 +17,7 @@ class TooltipController extends BaseController {
     super(options);
     this._showOnce = this._options.showOnce || false;
     this._cookieId = this._getCookieName(this._options.locator);
+    this._isShown = false;
   }
 
   /**
@@ -25,14 +26,18 @@ class TooltipController extends BaseController {
    */
   show(): void {
     if (this._showOnce) {
-      if (CookieStorage.get(this._cookieId) !== 'yes') {
+      if (CookieStorage.get(this._cookieId) !== 'yes' && !this._isShown) {
         CookieStorage.set(this._cookieId, 'yes', { expires: 9999 });
         this._store.dispatch({ type: 'show' });
         this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
+        this._isShown = true;
       }
     } else {
-      this._store.dispatch({ type: 'show' });
-      this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
+      if (!this._isShown) {
+        this._store.dispatch({ type: 'show' });
+        this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
+        this._isShown = true;  
+      }
     }
   }
 
@@ -41,8 +46,11 @@ class TooltipController extends BaseController {
    * @public
    */
   close(): void {
-    this._store.dispatch({ type: 'close' });
-    this._eventBus.publish(`close${this._id}`, { locator: this._options.locator });
+    if (this._isShown) {
+      this._store.dispatch({ type: 'close' });
+      this._eventBus.publish(`close${this._id}`, { locator: this._options.locator });
+      this._isShown = false;
+    }
   }
 
   /**

--- a/src/component/tooltip/tooltip-controller.js
+++ b/src/component/tooltip/tooltip-controller.js
@@ -36,7 +36,7 @@ class TooltipController extends BaseController {
       if (!this._isShown) {
         this._store.dispatch({ type: 'show' });
         this._eventBus.publish(`show${this._id}`, { locator: this._options.locator });
-        this._isShown = true;  
+        this._isShown = true;
       }
     }
   }


### PR DESCRIPTION
### What is the goal?

Avoid close if a tooltip is already closed

- [x] It passses the `jt-frontend` lint commands (`--lint-js`, `--lint-less`, `--lint-coffee`, ...)
- [x] The `README.md` has been updated accordingly

### How is being implemented?

We include a flag which on the first moment is equals to false. Then, if we show the tooltip, we set to true. Then, we only dispatch close event if that flag is true.

### Reviewers

@jobandtalent/frontend 